### PR TITLE
Fix path reference inside _send method

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -95,7 +95,7 @@ Push.prototype._send = function () {
   var self = this
 
   return new Promise(function (resolve, reject) {
-    var stream = self.res.push(this.path, {
+    var stream = self.res.push(self.path, {
       response: self.headers,
     })
 


### PR DESCRIPTION
This should fix the `GOAWAY` error you were getting during tests in #6.